### PR TITLE
TargetGenerator with Test

### DIFF
--- a/src/components/PlayerAddition.js
+++ b/src/components/PlayerAddition.js
@@ -55,7 +55,8 @@ const PlayerAddition = (props) => {
                         name: PlayerName,
                         nameLowerCase: PlayerNameLowCase,
                         isAlive: true,
-                        score: 0
+                        score: 0,
+                        targets: {}
                     })
                     //logs player added
                     .then((docRef) => {

--- a/src/components/TargetGenerator.js
+++ b/src/components/TargetGenerator.js
@@ -1,0 +1,58 @@
+function randomizeArray(array) {
+    for (let i = 0; i < array.length - 1; i++) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [array[i], array[j]] = [array[j], array[i]];
+    }
+    return array;
+}
+//Have a map that stores player : {# of assassins, last target index, list of previous targets}
+
+function TargetGenerator(users) {     
+    const targetList = randomizeArray([...users]);
+    console.log("targetList created: ", targetList)
+    const playerList = randomizeArray([...users]);
+    console.log("playerList created: ", playerList);
+    
+    //delcares max num of targets
+    const MAXTARGETS = users.length > 15 ? 3 : 2;
+
+    const playerData = {};
+    for (let i = 0; i < users.length; i++) {
+        const data =  {
+            numOfAssassins: 0, 
+            lastTargetIndex: i - 1, 
+            prevTargets: []}; 
+        playerData[users[i]] = data;
+    }
+    console.log("playerData initiated: ", playerData);
+    const targetMap = new Map();
+    
+    for (let playerDex = 0; playerDex < users.length; playerDex++) {
+        const currPlayer = playerList[playerDex];
+        targetMap.set(currPlayer, []);
+
+        for (let targetCount = 0; targetCount < MAXTARGETS; targetCount++) {
+            let targetIndex = (playerData[currPlayer].lastTargetIndex + 1) % users.length;
+            const target = targetList[targetIndex];
+            const originalDex = targetIndex;
+            while (playerData[target].numOfAssassins == MAXTARGETS 
+                   || target === currPlayer) {
+                targetIndex = (targetIndex + 1) % users.length;
+                if (targetIndex == originalDex) {
+                    console.log(`had to break for ${currPlayer}`)
+                    break;
+                }
+            }
+            targetMap.get(currPlayer).push(target);
+            playerData[currPlayer].lastTargetIndex = targetIndex;
+            playerData[currPlayer].prevTargets.push(target);
+            playerData[target].numOfAssassins += 1;
+        }
+    }
+
+    console.log("targetMap created: ", targetMap);
+    console.log("playerData finalized: ", playerData);
+    return targetMap;
+};
+
+export default TargetGenerator;

--- a/src/components/TargetGeneratorTest.js
+++ b/src/components/TargetGeneratorTest.js
@@ -1,0 +1,44 @@
+import TargetGenerator from './TargetGenerator';
+import { Button } from '@chakra-ui/react';
+
+const TargetGeneratorTest = () => {
+    const Test = () => {
+        let users = ['David', 'Zoey', 'John', 'Min', 'Andy', 'Joey', 'YuRa', 'Robby', 'Ricardo', 'Diegs'];
+        users.push('Matt', 'Will', 'Jordan H', 'Jordan M', 'Hadley', 'Nathan');
+        const targetMap = TargetGenerator(users);
+        console.log('Generated Target Map');
+        
+        targetMap.forEach((targets, user) => {
+            console.log(`${user} has targets: ${targets}`);
+            if (targets.length < 2 || targets.length > 3) {
+            console.error(`Error: check ${user}'s # of targets`);
+            }
+        });
+        
+        const AssassinVal = new Map();
+        for (let i = 0; i < users.length; i++) AssassinVal.set(users[i], 0);
+        
+        targetMap.forEach((targets, user) => {
+            targets.forEach((player) => {
+                AssassinVal.set(player, AssassinVal.get(player) + 1);
+            });
+        });
+
+        AssassinVal.forEach((val, player) => {
+            console.log(`${player} has ${val} hit(s) on them`);
+        });
+    }
+
+    return (  
+        <div>
+            <Button
+            onClick = {Test}
+            >
+                Generate Targets!
+            </Button>
+        </div>
+    );
+}
+ 
+export default TargetGeneratorTest;
+

--- a/src/pages/PlayerListPage.js
+++ b/src/pages/PlayerListPage.js
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import { Button, Flex, Heading } from '@chakra-ui/react';
 import PlayerAddition from '../components/PlayerAddition';
 import PlayerList from '../components/PlayerList';
+import TargetGeneratorTest from "../components/TargetGeneratorTest";
 
 const PlayerListPage = () => {
 


### PR DESCRIPTION
Created a target generator that initially assigns people with 2/3 targets depending on the number of players.
Test has two modes that can trigger the 2/3 target difference. Simply add a button on the page and check logs for the details.