### PR TITLE
KillButton Book Keeping (DB)

### DIFF
--- a/src/components/AlivePlayersList.js
+++ b/src/components/AlivePlayersList.js
@@ -28,7 +28,7 @@ const AlivePlayersList = (props) => {
     const playerAlivePlayersQuery = query(
         playerCollectionRef,
         where("isAlive", "==", true),
-        orderBy("score")
+        orderBy("score", "desc")
     );
 
     // Initialize state to keep track of the current list of players
@@ -36,20 +36,15 @@ const AlivePlayersList = (props) => {
 
     // When the component mounts, subscribe to the query and update the state whenever it changes
     useEffect(() => {
-        console.log("Running useEffect in AlivePlayersList");
 
         // subscribe to changes in the query results
         const unsubscribe = onSnapshot(playerAlivePlayersQuery, (snapshot) => {
-            console.log("snapshot: ", snapshot);
 
             // Get the updated list of players from the snapshot
             const updatedPlayers = snapshot.docs.map((doc) => ({
                 name: doc.data().name,
                 score: doc.data().score,
             }));
-
-            console.log("updatedPlayers: ", updatedPlayers);
-
             // Update the state with the new values
             setPlayers(updatedPlayers);
         });
@@ -58,7 +53,6 @@ const AlivePlayersList = (props) => {
         return () => unsubscribe();
     }, []); // empty dependency array means this effect will only run when the component mounts
 
-    console.log("players: ", players); // debug
 
     if (players.length === 0) {
         return null;

--- a/src/components/AssasinsSelection.js
+++ b/src/components/AssasinsSelection.js
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import { db } from '../utils/firebase';
+import { collection, query, getDocs, where, onSnapshot, updateDoc } from "firebase/firestore";
+import { Select, Flex, Button } from '@chakra-ui/react';
+
+const AssasinsSelection = (props) => {
+    const { roomID, killedPlayerNamed, killedPlayerPoints, triggerAS, setTriggerAS } = props;
+    const [possibleAssassin, setPossibleAssassin] = useState([]);
+    const [selectedAssassin, setSelectedAssassin] = useState('');
+    const playerCollectionRef = collection(db, 'rooms', roomID, 'players');
+    const [editableArray, setEditableArray] = useState([]);
+    let newPoints = killedPlayerPoints;
+
+    const handleChange = (event) => {
+        setSelectedAssassin(event.target.value);
+    };
+
+    useEffect(() => {
+        const playerQuery = query(playerCollectionRef, where('name', '==', killedPlayerNamed));
+        const unsubscribe = onSnapshot(playerQuery, (snapshot) => {
+            if (!snapshot.empty) {
+                const playerData = snapshot.docs[0].data();
+                setPossibleAssassin(playerData.assassins);
+            } else {
+                console.error("No documents found with the specified query.");
+            }
+        });
+        return () => unsubscribe();
+    }, [killedPlayerNamed]);
+
+    const removeAssassin = async () => {
+        if (selectedAssassin === '') {
+            console.log('Please select an assassin!!!');
+            return;
+        }
+        console.log("Removing assassin: ", selectedAssassin);
+        const assassinQuery = query(playerCollectionRef, where('name', '==', selectedAssassin));
+        
+        try {
+            const querySnapshot = await getDocs(assassinQuery);
+            const assassinData = querySnapshot.docs[0].data();
+            const assassinRef = querySnapshot.docs[0].ref;
+            setEditableArray([...assassinData.targets]);
+            const index = editableArray.indexOf(killedPlayerNamed);
+            const spliced = editableArray.slice();
+            spliced.splice(index, 1);
+            setEditableArray(spliced);
+            await updateDoc(assassinRef, {
+                targets: spliced,
+                score: assassinData.score + newPoints 
+            });
+        } catch (error) {
+            console.error("Error removing player: ", error);
+        }
+        setTriggerAS(false); // Use the passed callback to update the state in the parent component
+    };
+
+    return (
+        <>
+            {triggerAS && (
+                <form>
+                    <Flex padding='10px'>
+                        <Select 
+                            placeholder='Select Assassin'
+                            value={selectedAssassin}
+                            onChange={handleChange}
+                        >
+                            <option key='' value=''></option>
+                            {possibleAssassin.map((player, index) => (
+                                <option key={index} value={player}>
+                                    {player}
+                                </option>
+                            ))}
+                        </Select>
+                        <Button 
+                            onClick={removeAssassin}
+                            colorScheme='red'
+                            size='lg'
+                        >
+                            Assassin
+                        </Button>
+                    </Flex>
+                </form>
+            )}
+        </>
+    );
+};
+
+export default AssasinsSelection;

--- a/src/components/AssasinsSelection.js
+++ b/src/components/AssasinsSelection.js
@@ -1,18 +1,20 @@
 import React, { useEffect, useState } from 'react';
 import { db } from '../utils/firebase';
 import { collection, query, getDocs, where, onSnapshot, updateDoc } from "firebase/firestore";
-import { Select, Flex, Button } from '@chakra-ui/react';
+import { Select, Flex, Button, Alert, AlertIcon, AlertTitle, AlertDescription, Box } from '@chakra-ui/react';
 
 const AssasinsSelection = (props) => {
     const { roomID, killedPlayerNamed, killedPlayerPoints, triggerAS, setTriggerAS } = props;
     const [possibleAssassin, setPossibleAssassin] = useState([]);
     const [selectedAssassin, setSelectedAssassin] = useState('');
+    const [showAlert, setShowAlert] = useState(false); // State to control the alert visibility
     const playerCollectionRef = collection(db, 'rooms', roomID, 'players');
     const [editableArray, setEditableArray] = useState([]);
     let newPoints = killedPlayerPoints;
 
     const handleChange = (event) => {
         setSelectedAssassin(event.target.value);
+        setShowAlert(false); // Hide alert when an assassin is selected
     };
 
     useEffect(() => {
@@ -30,12 +32,13 @@ const AssasinsSelection = (props) => {
 
     const removeAssassin = async () => {
         if (selectedAssassin === '') {
-            console.log('Please select an assassin!!!');
+            setShowAlert(true); // Show alert if no assassin is selected
             return;
         }
+
         console.log("Removing assassin: ", selectedAssassin);
         const assassinQuery = query(playerCollectionRef, where('name', '==', selectedAssassin));
-        
+
         try {
             const querySnapshot = await getDocs(assassinQuery);
             const assassinData = querySnapshot.docs[0].data();
@@ -59,26 +62,37 @@ const AssasinsSelection = (props) => {
         <>
             {triggerAS && (
                 <form>
-                    <Flex padding='10px'>
-                        <Select 
-                            placeholder='Select Assassin'
-                            value={selectedAssassin}
-                            onChange={handleChange}
-                        >
-                            <option key='' value=''></option>
-                            {possibleAssassin.map((player, index) => (
-                                <option key={index} value={player}>
-                                    {player}
-                                </option>
-                            ))}
-                        </Select>
-                        <Button 
-                            onClick={removeAssassin}
-                            colorScheme='red'
-                            size='lg'
-                        >
-                            Assassin
-                        </Button>
+                    <Flex padding='10px' direction="column" align="center">
+                        {showAlert && (
+                            <Box mb={4} width="100%" >
+                                <Alert status="error" >
+                                    <AlertIcon />
+                                    <AlertTitle>Please select an assassin</AlertTitle>
+                                    <AlertDescription>You need to choose an assassin to proceed.</AlertDescription>
+                                </Alert>
+                            </Box>
+                        )}
+                        <Flex width="100%" justifyContent="center">
+                            <Select 
+                                placeholder='Select Assassin'
+                                value={selectedAssassin}
+                                onChange={handleChange}
+                            >
+                                {possibleAssassin.map((player, index) => (
+                                    <option key={index} value={player}>
+                                        {player}
+                                    </option>
+                                ))}
+                            </Select>
+                            <Button 
+                                onClick={removeAssassin}
+                                colorScheme='red'
+                                size='lg'
+                                ml={3}
+                            >
+                                Assassin
+                            </Button>
+                        </Flex>
                     </Flex>
                 </form>
             )}

--- a/src/components/DeadPlayersList.js
+++ b/src/components/DeadPlayersList.js
@@ -30,16 +30,11 @@ const DeadPlayersList = (props) => {
         where("isAlive", "==", false),
     );
 
-    // Initialize state to keep track of the current list of players
     const [players, setPlayers] = useState([]); // array of player objects
 
-    // When the component mounts, subscribe to the query and update the state whenever it changes
     useEffect(() => {
-        console.log("Running useEffect in AlivePlayersList");
 
-        // subscribe to changes in the query results
         const unsubscribe = onSnapshot(playerAlivePlayersQuery, (snapshot) => {
-            console.log("snapshot: ", snapshot);
 
             // Get the updated list of players from the snapshot
             const updatedPlayers = snapshot.docs.map((doc) => ({
@@ -48,15 +43,12 @@ const DeadPlayersList = (props) => {
 
             console.log("updatedPlayers: ", updatedPlayers);
 
-            // Update the state with the new values
             setPlayers(updatedPlayers);
         });
 
-        // Clean up the subscription when the component unmounts
         return () => unsubscribe();
-    }, []); // empty dependency array means this effect will only run when the component mounts
+    }, []); 
 
-    console.log("players: ", players); // debug
 
     if (players.length === 0) {
         return null;

--- a/src/components/KillButton.js
+++ b/src/components/KillButton.js
@@ -1,35 +1,29 @@
-import React, {useState} from 'react';
-import { Flex, 
-        Button, 
-        Select,
-         } from '@chakra-ui/react';
+import React, { useState } from 'react';
+import { Flex, Button, Select, Box, Alert, AlertIcon, AlertTitle, AlertDescription } from '@chakra-ui/react';
 import { db } from '../utils/firebase';
-import {query,  
-        updateDoc,
-        collection,
-        getDocs,
-        where
-        } from "firebase/firestore"; 
+import { query, updateDoc, collection, getDocs, where } from "firebase/firestore";
 
-   
 const KillButton = (props) => {
     const [selectedPlayer, setSelectedPlayer] = useState('');
+    const [showAlert, setShowAlert] = useState(false); // State to control the alert visibility
     const roomID = props.roomID;
     const playerData = props.arrayOfPlayers;
     const onPlayerKilled = props.onPlayerKilled;
-    
-   // Define a function to handle changes to the select element
+
+    // Define a function to handle changes to the select element
     const handleChange = (event) => {
         setSelectedPlayer(event.target.value);
+        setShowAlert(false); // Hide alert when a player is selected
     };
-    
+
     const handleKillPlayer = async () => {
         if (selectedPlayer === '') { // Check if a player has been selected
-            console.log('Please select a player!!!');
+            setShowAlert(true); // Show alert if no player is selected
             return;
-        };
+        }
+
         // Create a reference to the 'players' subcollection in the specified room
-        const playerCollectionRef = collection(db, 'rooms', roomID, 'players'); //This takes us to the players folder
+        const playerCollectionRef = collection(db, 'rooms', roomID, 'players'); // This takes us to the players folder
         const playerQuery = query(playerCollectionRef, where('name', '==', selectedPlayer)); // get the players with this name
 
         try {
@@ -37,8 +31,8 @@ const KillButton = (props) => {
             const playerdoc = querySnapshot.docs[0].ref;
             const playerData = querySnapshot.docs[0].data();
             props.killedPlayerPoints(playerData.score);
-            await updateDoc(playerdoc, {score: 0});
-            await updateDoc(playerdoc, {isAlive: false});
+            await updateDoc(playerdoc, { score: 0 });
+            await updateDoc(playerdoc, { isAlive: false });
             props.onPlayerKilled(selectedPlayer);
         } catch (error) {
             console.error('Error fetching player documents:', error);
@@ -46,26 +40,35 @@ const KillButton = (props) => {
     }
 
     return (
-        
         <form>
-                <Flex padding='10px'>
-                    <Select placeholder = 'Select player to Kill'
-                            value = {selectedPlayer}
-                            onChange = {handleChange}>
-                        <option key = '' value = ''></option>
+            <Flex padding='10px' direction="column" align="center">
+                {showAlert && (
+                    <Box mb={4} width="100%">
+                        <Alert status="error">
+                            <AlertIcon />
+                            <AlertTitle>Please select a player</AlertTitle>
+                            <AlertDescription>You need to choose a player to proceed.</AlertDescription>
+                        </Alert>
+                    </Box>
+                )}
+                <Flex width="100%" justifyContent="center">
+                    <Select placeholder='Select player to Kill'
+                        value={selectedPlayer}
+                        onChange={handleChange}>
                         {playerData.map((player, index) => (
-                            <option key = {index} 
-                                    value = {player} >
-                                        {player}
+                            <option key={index} value={player}>
+                                {player}
                             </option>
                         ))}
                     </Select>
                     <Button onClick={handleKillPlayer}
                         colorScheme='red'
-                        size = 'lg'>
-                    Kill
+                        size='lg'
+                        ml={3}>
+                        Kill
                     </Button>
-                </Flex> 
+                </Flex>
+            </Flex>
         </form>
     );
 };

--- a/src/components/KillButton.js
+++ b/src/components/KillButton.js
@@ -10,6 +10,7 @@ import {query,
         getDocs,
         where
         } from "firebase/firestore"; 
+
    
 const KillButton = (props) => {
     const [selectedPlayer, setSelectedPlayer] = useState('');
@@ -26,7 +27,7 @@ const KillButton = (props) => {
         if (selectedPlayer === '') { // Check if a player has been selected
             console.log('Please select a player!!!');
             return;
-        }
+        };
         // Create a reference to the 'players' subcollection in the specified room
         const playerCollectionRef = collection(db, 'rooms', roomID, 'players'); //This takes us to the players folder
         const playerQuery = query(playerCollectionRef, where('name', '==', selectedPlayer)); // get the players with this name
@@ -34,21 +35,23 @@ const KillButton = (props) => {
         try {
             const querySnapshot = await getDocs(playerQuery); // Fetch the documents that match the query
             const playerdoc = querySnapshot.docs[0].ref;
+            const playerData = querySnapshot.docs[0].data();
+            props.killedPlayerPoints(playerData.score);
+            await updateDoc(playerdoc, {score: 0});
             await updateDoc(playerdoc, {isAlive: false});
-            onPlayerKilled();
+            props.onPlayerKilled(selectedPlayer);
         } catch (error) {
             console.error('Error fetching player documents:', error);
         }
     }
 
     return (
+        
         <form>
                 <Flex padding='10px'>
                     <Select placeholder = 'Select player to Kill'
                             value = {selectedPlayer}
-                            onChange = {handleChange}
-                            borderColor='tomato'
-                            size = 'lg'>
+                            onChange = {handleChange}>
                         <option key = '' value = ''></option>
                         {playerData.map((player, index) => (
                             <option key = {index} 
@@ -57,10 +60,10 @@ const KillButton = (props) => {
                             </option>
                         ))}
                     </Select>
-                    <Button onClick={handleKillPlayer} 
-                            colorScheme='red'
-                            size = 'lg'>
-                        Kill
+                    <Button onClick={handleKillPlayer}
+                        colorScheme='red'
+                        size = 'lg'>
+                    Kill
                     </Button>
                 </Flex> 
         </form>

--- a/src/pages/GameMasterView.js
+++ b/src/pages/GameMasterView.js
@@ -1,26 +1,54 @@
 import React from 'react';
+import { useState } from 'react';
 import AlivePlayersList from '../components/AlivePlayersList';
 import { useParams, useLocation } from 'react-router-dom';
 import TargetGenerator from '../components/TargetGenerator';
 import DeadPlayersList from '../components/DeadPlayersList';
-import { Flex, Heading} from '@chakra-ui/react';
+import { Flex, Heading } from '@chakra-ui/react';
+import KillButton from '../components/KillButton';
+import AssasinsSelection from '../components/AssasinsSelection';
 
 const GameMasterView = () => {
     const { roomID } = useParams();    
-    const {arrayOfPlayers} = useLocation().state || {arrayOfPlayers: []};
+    const { arrayOfPlayers } = useLocation().state || { arrayOfPlayers: [] };
+    const [killedPlayerNamed, setKilledPlayerNamed] = useState('');
+    const [killedPlayerPointed, setKilledPlayerPointed] = useState(0);
+    const [triggerAS, setTriggerAS] = useState(false);
+
+    const handleKillPlayer = (killedPlayerName, setAS) => {
+        setKilledPlayerNamed(killedPlayerName); // sets the name of the player to be killed 
+        setTriggerAS(true);
+    };
+
+    const handleKillPlayerPoints = (killedPlayerPoints) => {
+        setKilledPlayerPointed(killedPlayerPoints);
+    };
 
     return (
         <div>
-            <Heading >Game Master View</Heading>
-            <Flex   direction="row" 
-                    justifyContent="center">
-                <AlivePlayersList roomID = {roomID}/>
-                <DeadPlayersList roomID = {roomID}/>
+            <Heading>Game Master View</Heading>
+            <Flex direction="row" justifyContent="center">
+                <AlivePlayersList roomID={roomID} />
+                <DeadPlayersList roomID={roomID} />
             </Flex>
-            
-            <TargetGenerator arrayOfPlayers={arrayOfPlayers} 
-                             roomID={roomID} />    
-            {roomID}         
+            <KillButton 
+                arrayOfPlayers={arrayOfPlayers}
+                roomID={roomID}
+                onPlayerKilled={handleKillPlayer}
+                killedPlayerPoints={handleKillPlayerPoints}
+            />
+            <TargetGenerator 
+                arrayOfPlayers={arrayOfPlayers} 
+                roomID={roomID} 
+            />
+            <AssasinsSelection  
+                roomID={roomID}
+                arrayOfPlayers={arrayOfPlayers} 
+                killedPlayerPoints={killedPlayerPointed}
+                killedPlayerNamed={killedPlayerNamed}
+                triggerAS={triggerAS}
+                setTriggerAS={setTriggerAS} // Pass the setter function as a prop
+            />         
         </div>
     );
 }

--- a/src/pages/GameMasterView.js
+++ b/src/pages/GameMasterView.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import { useState } from 'react';
 import AlivePlayersList from '../components/AlivePlayersList';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, 
+         useLocation } from 'react-router-dom';
 import TargetGenerator from '../components/TargetGenerator';
 import DeadPlayersList from '../components/DeadPlayersList';
-import { Flex, Heading } from '@chakra-ui/react';
+import { Flex, 
+         Heading,
+         Spacer } from '@chakra-ui/react';
 import KillButton from '../components/KillButton';
 import AssasinsSelection from '../components/AssasinsSelection';
 
@@ -27,7 +30,7 @@ const GameMasterView = () => {
     return (
         <div>
             <Heading>Game Master View</Heading>
-            <Flex direction="row" justifyContent="center">
+            <Flex direction="row" justifyContent="center" gap='20'>
                 <AlivePlayersList roomID={roomID} />
                 <DeadPlayersList roomID={roomID} />
             </Flex>

--- a/src/pages/PlayerListPage.js
+++ b/src/pages/PlayerListPage.js
@@ -12,7 +12,6 @@ import { Button,
 import PlayerAddition from '../components/PlayerAddition';
 import PlayerList from '../components/PlayerList';
 import PlayerRemove from "../components/PlayerRemove";
-import KillButton from '../components/KillButton';
 import {collection, query, getDocs} from 'firebase/firestore';
 import {db} from '../utils/firebase';
 
@@ -108,9 +107,6 @@ const PlayerListPage = () => {
         }
     }
 
-    const handlekill = (PlayerName) => {
-        console.log(`{The player has been killed}`);
-    }
                
     return (
         <Flex>
@@ -132,15 +128,18 @@ const PlayerListPage = () => {
             <Heading as="h2" size="xl" mb={4}>
                 Room ID: {roomID}
             </Heading>
-            <PlayerAddition roomID = {roomID} onPlayerAdded = {handlePlayerAdded}/>
+            <PlayerAddition roomID = {roomID} 
+                            onPlayerAdded = {handlePlayerAdded}/>
             <PlayerList arrayOfPlayers = {arrayOfPlayers}/>        
-            <PlayerRemove roomID = {roomID} arrayOfPlayers = {arrayOfPlayers} onPlayerRemoved = {handlePlayerRemoved}/>
-            <Button colorScheme='teal' variant='outline' onClick={handleLobbyRoom}>
+            <PlayerRemove roomID = {roomID} 
+                            arrayOfPlayers = {arrayOfPlayers} 
+                            onPlayerRemoved = {handlePlayerRemoved}/>
+            <Button colorScheme='teal' 
+                    variant='outline' 
+                    onClick={handleLobbyRoom}>
                 Begin Game
             </Button>
-            <KillButton arrayOfPlayers = {arrayOfPlayers}
-                        roomID = {roomID}
-                        onPlayerKilled = {handlekill}/>
+            
         </Flex>
     )
 }


### PR DESCRIPTION
 - Add dropdown for assassin’s name that appears after selecting the player that is being killed (only display the names of the assassins as options; query player’s assassins field)
 - Player’s points are added to assassin’s points
 - Set the target’s points to 0
 - Move target to DeadPlayersList
 - Remove the target from the assassin’s target field
 - I have not done the regen target yet
 - I added space in between lists on GameMaster page
 - I added an alert if people choose no one and try to kill or assinate (DB)