### PR TITLE
Typos and Naming Fixed, Remapping Significantly Improved

### DIFF
--- a/src/components/DeadPlayerReviveButton.js
+++ b/src/components/DeadPlayerReviveButton.js
@@ -22,6 +22,7 @@ const DeadPlayerReviveButton = (props) => {
 
     //handling for when revive image for player is clicked
     const handleReviveClicked = async () => {
+        console.error('playerName: ', player);
         if (player === '' || !player) {
             return createAlert('error', 'Error', 'player undefined', 1500);
         }
@@ -29,7 +30,7 @@ const DeadPlayerReviveButton = (props) => {
         //revives and remaps player
         await updateIsAliveForPlayer(player, true, roomID);
         const activePlayers = [...arrayOfAlivePlayers, player];
-        const [target, assassin] = await handleRegeneration(player, player, activePlayers, roomID);
+        const [target, assassin] = await handleRegeneration([player], [player], activePlayers, roomID);
         handleAddNewAssassins(assassin);
         handleAddNewTargets(target);
         handleSetShowMessageToTrue();

--- a/src/components/PlayerAddition.js
+++ b/src/components/PlayerAddition.js
@@ -24,7 +24,7 @@ const PlayerAddition = (props) => {
 
     //handles function to add player
     const handleAddPlayer = async () => {
-        if (playerName === '') {
+        if (playerName.replace(/\s/g, '') === '') {
             return createAlert('error', 'Error', 'name cannot be blank', 1500);
         }
         try {

--- a/src/components/RemapPlayers.js
+++ b/src/components/RemapPlayers.js
@@ -63,20 +63,18 @@ const RemapPlayers = (handleRemapping, createAlert) => {
                 }
 
                 //final case if no suitable matches were found
-                if (newTargetArray.length === 0) {
-                    console.error('running final case for targets');
+                if (newTargetArray.length < MAXTARGETS - 1) {
+                    console.error('running final case for targets on ', player);
                     try {
                         const lastCaseTargetForPlayer = await fetchAlivePlayersByAscendAssassinsLengthForRoom(roomID, player);
                         console.log(`lastCaseTargetForPlayer: `, lastCaseTargetForPlayer);
-                        let index = 0;
                         for (const target of lastCaseTargetForPlayer) {
                             if (target) {
                                 newTargetArray.push(target.name);
                                 await updateAssassinsForPlayer(target.name, [...target.assassins, player], roomID);
                                 await handleRemapping("New target for " + player + ": " + target.name);
-                                index++;
                             }
-                            if (index >= MAXTARGETS) {
+                            if (newTargetArray.length >= MAXTARGETS) {
                                 break;
                             }
                         }
@@ -140,21 +138,20 @@ const RemapPlayers = (handleRemapping, createAlert) => {
                 }
 
                 //final case if no suitable matches were found
-                if (newAssassinArray.length === 0) {
-                    console.error('running final case for assassins');
+                if (newAssassinArray.length < MAXTARGETS - 1) {
+                    console.error('running final case for assassins on ', player);
                     try {
                         const lastCaseAssassinForPlayer = await fetchAlivePlayersByAscendTargetsLengthForRoom(roomID, player);
                         console.log(`lastCaseAssassinForPlayer: `, lastCaseAssassinForPlayer);
-                        let index = 0;
                         for (const possibleLastCaseAssassin of lastCaseAssassinForPlayer) {
                             if (possibleLastCaseAssassin) {
                                 newAssassinArray.push(possibleLastCaseAssassin.name);
                                 await updateTargetsForPlayer(possibleLastCaseAssassin.name, [...possibleLastCaseAssassin.targets, player], roomID);
                                 await handleRemapping("New target for " + possibleLastCaseAssassin.name + ": " + player);
-                                index++
                             }
-                            if (index >= MAXTARGETS) {
+                            if (newAssassinArray.length >= MAXTARGETS) {
                                 break;
+                                console.error('breaking');
                             }
                         }
                     } catch (error) {

--- a/src/components/ResetTargetsButton.js
+++ b/src/components/ResetTargetsButton.js
@@ -45,7 +45,7 @@ const ResetTargetsButton = ({arrayOfPlayers, addLog, roomID}) => {
     //actions that occur when clicking yes
     const onYesClose = async () => {
         await UpdateDatabase(arrayOfPlayers, targetMap);
-        await addLog("Reseting Targets");
+        await addLog("Resetting Targets");
         for (const player of arrayOfPlayers) {
             await addLog('New Target(s) for ' + player + ': ' + targetMap.get(player).join(', '));
             console.log('looping for ' + player);

--- a/src/components/dbCalls.js
+++ b/src/components/dbCalls.js
@@ -257,7 +257,7 @@ const fetchPlayerForRoom = async (playerName, roomID) => {
         }
     }
     catch (error) {
-        console.error('Error fetching player: ', error);
+        console.error(`Error fetching player ${playerName}: `, error);
     }
 }
 
@@ -299,7 +299,9 @@ const addPlayerForRoom = async (player, roomID) => {
         isAlive: true,
         score: 10,
         targets: [],
+        targetsLength: 0,
         assassins: [],
+        assassinsLength: 0,
         openSeason: false
     })
     .then((docRef) => {
@@ -333,7 +335,10 @@ const updateAssassinsForPlayer = async (player, assassins, roomID) => {
         const playerQuery = query(playerCollectionRef, where('name', '==', player));
         const playerSnapshot = await getDocs(playerQuery);
         const playerdoc = playerSnapshot.docs[0].ref;
-        await updateDoc(playerdoc, { assassins: assassins });
+        await updateDoc(playerdoc, { 
+            assassins: assassins,
+            assassinsLength: assassins.length 
+        });
     }
     catch (error) {
         console.error('Error updating player assassins: ', error);
@@ -347,7 +352,11 @@ const updateTargetsForPlayer = async (player, targets, roomID) => {
         const playerQuery = query(playerCollectionRef, where('name', '==', player));
         const playerSnapshot = await getDocs(playerQuery);
         const playerdoc = playerSnapshot.docs[0].ref;
-        await updateDoc(playerdoc, { targets: targets });
+        await updateDoc(playerdoc, { 
+            targets: targets,
+            targetsLength: targets.length
+        });
+
     }
     catch (error) {
         console.error('Error updating player targets: ', error);
@@ -391,11 +400,13 @@ const fetchAlivePlayersByAscendAssassinsLengthForRoom = async (roomID, player) =
         const playerCollectionRef = collection(db, 'rooms', roomID, 'players');
         const playerQuery = query(playerCollectionRef, 
                                   where('isAlive', '==', true),
-                                  orderBy('assassins'),
+                                  orderBy('assassinsLength', 'asc'),
+                                  orderBy('score', 'desc')
                                 );
         const playerSnapshot = await getDocs(playerQuery);
         const players = playerSnapshot.docs.map(doc => doc.data())
                                            .filter(doc => doc.name !== player);
+        console.log('players: ', players);
         return players;
     }
     catch (error) {
@@ -409,11 +420,13 @@ const fetchAlivePlayersByAscendTargetsLengthForRoom = async (roomID, player) => 
         const playerCollectionRef = collection(db, 'rooms', roomID, 'players');
         const playerQuery = query(playerCollectionRef, 
                                   where('isAlive', '==', true),
-                                  orderBy('targets')
+                                  orderBy('targetsLength', 'asc'),
+                                  orderBy('score', 'asc')
                                 );
         const playerSnapshot = await getDocs(playerQuery);
         const players = playerSnapshot.docs.map(doc => doc.data())
                                            .filter(doc => doc.name !== player);
+        console.log('players: ', players);
         return players;
     }
     catch (error) {


### PR DESCRIPTION
* Fixed bug with revival button where it would pass each char to be remapped rather than the full name
* Cannot add name with blank spaces only to player list
* Fixed typo from 'reseting' to 'resetting'
* Fixed bug where final case for remapping would take in the lexicographical order rather than array length, which would imbalance
* Imbalancing significantly reduced with larger playerbase